### PR TITLE
Implement LinkedIn company finder agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ npm run dev
 ```
 
 Gerekli API anahtarlarını `backend/.env.example` dosyasını kopyalayıp `.env` adında oluşturmayı unutmayın.
+
+LinkedIn şirket sayfasını bulmak için backend'deki `/find_linkedin` endpoint'ini
+kullanabilirsiniz.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,3 @@
-# Rename this file to .env and fill in your API keys
-OPENAI_API_KEY=sk-your-openai-key
-OTHER_SERVICE_TOKEN=replace-me
+# Example environment variables for InsightChain backend
+EXA_API_KEY=your_exa_api_key_here
+OPENAI_API_KEY=your_openai_api_key_here

--- a/backend/README.md
+++ b/backend/README.md
@@ -12,3 +12,15 @@ uvicorn main:app --reload
 `requirements.txt` scraping aracı için Playwright, Selenium ve Scrapy gibi ek kütühaneler içerir. Playwright kullanılacaksa `playwright install` komutu ile tarayıcıları kurmayı unutmayın.
 
 Yerel `.env` dosyanızı oluşturup gerekli API anahtarlarını tanımlayın.
+
+### LinkedIn Company Finder Endpoint
+
+Backend artık şirket adından LinkedIn sayfasını bulmak için `/find_linkedin`
+endpoint'ini sunar.
+
+```
+GET /find_linkedin?company=OpenAI
+```
+
+İsteğe bağlı `contacts=true` parametresi eklenirse, sayfadaki herkese açık
+çalışan kartları da toplanır.

--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -1,2 +1,3 @@
 from .search_agent import run_search
 from .scraper_agent import orchestrate_scraping
+from .linkedin_agent import orchestrate_linkedin

--- a/backend/agents/linkedin_agent.py
+++ b/backend/agents/linkedin_agent.py
@@ -1,0 +1,59 @@
+"""LinkedIn company finder agent powered by GPT-4."""
+
+import json
+from typing import Dict
+
+import openai
+
+from ..tools import linkedinfinder, linkedincontacts
+
+
+def make_prompt(company: str, want_contacts: bool) -> str:
+    """Construct the orchestration prompt for GPT-4."""
+    return (
+        "You are an orchestration agent for the InsightChain platform.\n"
+        "Your goal is:\n"
+        "Given a company name or website, find the most accurate LinkedIn company profile URL.\n"
+        "You have access to these tools:\n"
+        "- linkedinfinder: Finds the correct LinkedIn company page URL from a company name or web address, using web search APIs (Exa, SerpAPI, Brave, Google CSE).\n"
+        "- linkedincontacts: (Optional) Given a LinkedIn company page, extract publicly visible key employees and their positions (uses Playwright scraping).\n\n"
+        "Respond in this JSON format:\n"
+        "{\n"
+        "  \"selected_tool\": \"linkedinfinder\",\n"
+        "  \"parameters\": {\n"
+        f"    \"company_name\": \"{company}\"\n"
+        "  }\n"
+        "}\n"
+    )
+
+
+def call_gpt4(prompt: str) -> Dict[str, str]:
+    """Call the OpenAI API and return parsed JSON."""
+    response = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0,
+    )
+    content = response.choices[0].message["content"]
+    return json.loads(content)
+
+
+def orchestrate_linkedin(company: str, contacts: bool = False) -> Dict[str, object]:
+    """Main entrypoint that orchestrates LinkedIn finding (and optionally contacts)."""
+    prompt = make_prompt(company, contacts)
+    decision = call_gpt4(prompt)
+    tool_name = decision["selected_tool"]
+    params = decision.get("parameters", {})
+
+    tools_map = {"linkedinfinder": linkedinfinder}
+    if contacts:
+        tools_map["linkedincontacts"] = linkedincontacts
+
+    tool = tools_map.get(tool_name)
+    if not tool:
+        raise ValueError(f"Unknown tool selected: {tool_name}")
+
+    result = tool(**params)
+    if contacts and result.get("linkedin_url"):
+        result.update(linkedincontacts(result["linkedin_url"]))
+    return result

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, Query
 
-from .agents import orchestrate_scraping
+from .agents import orchestrate_scraping, orchestrate_linkedin
 
 app = FastAPI(title="InsightChain API")
 
@@ -15,6 +15,16 @@ def read_root():
 def scrape(url: str = Query(..., description="Company website URL")):
     """Endpoint that triggers the scraping workflow."""
     result = orchestrate_scraping(url)
+    return result
+
+
+@app.get("/find_linkedin")
+def find_linkedin(
+    company: str = Query(..., description="Company name or website"),
+    contacts: bool = Query(False, description="Also fetch public contacts"),
+):
+    """Endpoint that finds the LinkedIn company page (and optionally contacts)."""
+    result = orchestrate_linkedin(company, contacts)
     return result
 
 

--- a/backend/tools/__init__.py
+++ b/backend/tools/__init__.py
@@ -6,3 +6,4 @@ from .scraping_tools import (
     masscrawler,
     llmscraper,
 )
+from .linkedin_finder import linkedinfinder, linkedincontacts

--- a/backend/tools/linkedin_finder.py
+++ b/backend/tools/linkedin_finder.py
@@ -1,0 +1,55 @@
+import os
+from typing import Dict, List, Optional
+
+import requests
+from bs4 import BeautifulSoup
+from playwright.sync_api import sync_playwright
+
+EXA_API_URL = "https://api.exa.ai/search"
+EXA_API_KEY = os.getenv("EXA_API_KEY")
+
+
+def linkedinfinder(company_name: str) -> Dict[str, Optional[str]]:
+    """Search for the most relevant LinkedIn company page URL using Exa API."""
+    if not EXA_API_KEY:
+        raise ValueError("EXA_API_KEY not set")
+
+    query = f"site:linkedin.com/company {company_name}"
+    payload = {"query": query, "numResults": 3}
+    headers = {"Authorization": f"Bearer {EXA_API_KEY}"}
+    resp = requests.post(EXA_API_URL, json=payload, headers=headers, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+
+    for hit in data.get("results", []):
+        url = hit.get("url", "")
+        if "linkedin.com/company" in url:
+            return {"linkedin_url": url}
+    return {"linkedin_url": None}
+
+
+def linkedincontacts(company_url: str) -> Dict[str, List[Dict[str, str]]]:
+    """Extract publicly visible employee names and titles from a LinkedIn page."""
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.goto(company_url)
+        page.wait_for_load_state("networkidle")
+        html = page.content()
+        browser.close()
+
+    soup = BeautifulSoup(html, "html.parser")
+    employees: List[Dict[str, str]] = []
+    for card in soup.select("div.org-people-profile-card__profile-info"):
+        name_el = card.select_one("div>div.t-16")
+        title_el = card.select_one("div>div.t-14")
+        link_el = card.select_one("a.ember-view")
+        if name_el and title_el and link_el:
+            employees.append(
+                {
+                    "name": name_el.get_text(strip=True),
+                    "title": title_el.get_text(strip=True),
+                    "profile": "https://www.linkedin.com" + link_el.get("href"),
+                }
+            )
+    return {"employees": employees}


### PR DESCRIPTION
## Summary
- add LinkedIn finder tool using Exa search and optional contact scraping
- expose `orchestrate_linkedin` agent and new `/find_linkedin` endpoint
- document usage and environment variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687c10454ae4832f9735527968efc124