### PR TITLE
Fix import path in example workflow

### DIFF
--- a/backend/workflows/example_workflow.py
+++ b/backend/workflows/example_workflow.py
@@ -1,6 +1,6 @@
 """Örnek orchestrator workflow."""
 
-from . import agents
+from .. import agents
 
 
 def run(keyword: str) -> dict:


### PR DESCRIPTION
## Summary
- correct `agents` import to handle package structure
- run `py_compile` to validate imports

## Testing
- `python -m py_compile backend/workflows/example_workflow.py`

------
https://chatgpt.com/codex/tasks/task_b_687c1d21a9dc832f95e5c5b7436a4934