### PR TITLE
Fix uvicorn command paths in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 ## Hızlı Başlangıç
 
 ### Backend
+Komutları depo kök dizininden çalıştırın:
 ```bash
-cd backend
-pip install -r requirements.txt
-uvicorn main:app --reload
+pip install -r backend/requirements.txt
+uvicorn backend.main:app --reload
 ```
 
 ### Frontend

--- a/backend/README.md
+++ b/backend/README.md
@@ -3,10 +3,11 @@
 Bu dizin FastAPI tabanlı REST servislerini içerir. Her bir ajan ve workflow modüler olarak `agents/`, `tools/` ve `workflows/` klasörlerinde yer alır.
 
 ## Çalıştırma
-
+Komutları depo kök dizininden çalıştırın:
 ```bash
 pip install -r requirements.txt
-uvicorn main:app --reload
+cd ..
+uvicorn backend.main:app --reload
 ```
 
 `requirements.txt` scraping aracı için Playwright, Selenium ve Scrapy gibi ek kütühaneler içerir. Playwright kullanılacaksa `playwright install` komutu ile tarayıcıları kurmayı unutmayın.


### PR DESCRIPTION
## Summary
- update backend instructions in README.md
- clarify running backend from repo root in backend/README.md

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687c1f112a04832faff8ee861076c66a