### PR TITLE
Implement orchestrated company analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ Gerekli API anahtarlarını `backend/.env.example` dosyasını kopyalayıp `.env
 
 LinkedIn şirket sayfasını bulmak için backend'deki `/find_linkedin` endpoint'ini
 kullanabilirsiniz.
+Tam entegre analiz için `/analyze` endpoint'ine şirket web sitesini POST edin.

--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -1,3 +1,5 @@
 from .search_agent import run_search
 from .scraper_agent import orchestrate_scraping
 from .linkedin_agent import orchestrate_linkedin
+from .data_analyst_agent import analyze_data
+from .orchestrator_agent import run_pipeline

--- a/backend/agents/data_analyst_agent.py
+++ b/backend/agents/data_analyst_agent.py
@@ -1,0 +1,43 @@
+"""Data Analyst Agent that creates a final company report."""
+
+import json
+from typing import Dict
+
+import openai
+
+from ..tools import brave_news
+
+
+def make_prompt(
+    scrape_data: Dict[str, str],
+    linkedin_data: Dict[str, object],
+    news_data: Dict[str, object],
+) -> str:
+    """Construct a prompt combining all gathered information."""
+    return (
+        "You are a data analyst for the InsightChain platform.\n"
+        "Using the following scraped website data, LinkedIn info and recent news,\n"
+        "generate a concise report about the company.\n\n"
+        f"Website Data: {json.dumps(scrape_data)[:1000]}\n\n"
+        f"LinkedIn Data: {json.dumps(linkedin_data)[:1000]}\n\n"
+        f"News: {json.dumps(news_data)[:1000]}\n\n"
+        "Return a short summary."
+    )
+
+
+def analyze_data(
+    scrape_data: Dict[str, str], linkedin_data: Dict[str, object], query: str
+) -> Dict[str, str]:
+    """Run the Data Analyst agent and return final summary."""
+    try:
+        news_data = brave_news(query)
+    except Exception:
+        news_data = {"news": []}
+
+    prompt = make_prompt(scrape_data, linkedin_data, news_data)
+    response = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    summary = response.choices[0].message["content"]
+    return {"summary": summary, "news": news_data.get("news", [])}

--- a/backend/agents/orchestrator_agent.py
+++ b/backend/agents/orchestrator_agent.py
@@ -1,0 +1,19 @@
+"""Orchestrator agent that runs the full company analysis pipeline."""
+
+from typing import Dict
+
+from .scraper_agent import orchestrate_scraping
+from .linkedin_agent import orchestrate_linkedin
+from .data_analyst_agent import analyze_data
+
+
+def run_pipeline(company_url: str) -> Dict[str, object]:
+    """Run scraping, LinkedIn enrichment and final analysis."""
+    scrape_result = orchestrate_scraping(company_url)
+    linkedin_result = orchestrate_linkedin(company_url, contacts=True)
+    analysis_result = analyze_data(scrape_result, linkedin_result, company_url)
+    return {
+        "scrape": scrape_result,
+        "linkedin": linkedin_result,
+        "analysis": analysis_result,
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,11 @@
 from fastapi import FastAPI, Query
+from pydantic import BaseModel
 
-from .agents import orchestrate_scraping, orchestrate_linkedin
+from .agents import (
+    orchestrate_scraping,
+    orchestrate_linkedin,
+    run_pipeline,
+)
 
 app = FastAPI(title="InsightChain API")
 
@@ -25,6 +30,17 @@ def find_linkedin(
 ):
     """Endpoint that finds the LinkedIn company page (and optionally contacts)."""
     result = orchestrate_linkedin(company, contacts)
+    return result
+
+
+class AnalyzeRequest(BaseModel):
+    website: str
+
+
+@app.post("/analyze")
+def analyze(req: AnalyzeRequest):
+    """Run the full analysis pipeline for a company website."""
+    result = run_pipeline(req.website)
     return result
 
 

--- a/backend/tools/__init__.py
+++ b/backend/tools/__init__.py
@@ -7,3 +7,4 @@ from .scraping_tools import (
     llmscraper,
 )
 from .linkedin_finder import linkedinfinder, linkedincontacts
+from .news_search import brave_news

--- a/backend/tools/news_search.py
+++ b/backend/tools/news_search.py
@@ -1,0 +1,26 @@
+import os
+from typing import Dict, List
+
+import requests
+
+BRAVE_API_URL = "https://api.search.brave.com/res/v1/news/search"
+BRAVE_API_KEY = os.getenv("BRAVE_API_KEY")
+
+
+def brave_news(query: str) -> Dict[str, List[Dict[str, str]]]:
+    """Fetch latest news articles about the query using Brave Search API."""
+    if not BRAVE_API_KEY:
+        raise ValueError("BRAVE_API_KEY not set")
+
+    params = {"q": query, "count": 3}
+    headers = {
+        "Accept": "application/json",
+        "X-Subscription-Token": BRAVE_API_KEY,
+    }
+    resp = requests.get(BRAVE_API_URL, params=params, headers=headers, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    items: List[Dict[str, str]] = []
+    for hit in data.get("results", []):
+        items.append({"title": hit.get("title", ""), "url": hit.get("url", "")})
+    return {"news": items}

--- a/backend/workflows/__init__.py
+++ b/backend/workflows/__init__.py
@@ -1,2 +1,3 @@
 from .example_workflow import run as run_example
 from .scraping_workflow import run as run_scraper
+from .company_analysis_workflow import run as run_company_analysis

--- a/backend/workflows/company_analysis_workflow.py
+++ b/backend/workflows/company_analysis_workflow.py
@@ -1,0 +1,8 @@
+"""Workflow that runs the full analysis pipeline."""
+
+from ..agents import run_pipeline
+
+
+def run(website: str) -> dict:
+    """Run analysis pipeline for the given website."""
+    return run_pipeline(website)

--- a/frontend/src/components/MainCard.tsx
+++ b/frontend/src/components/MainCard.tsx
@@ -1,6 +1,38 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 export default function MainCard() {
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState('');
+  const [result, setResult] = useState('');
+
+  const handleSearch = async () => {
+    if (!query) return;
+    setLoading(true);
+    setResult('');
+    setStatus('Web sitesi inceleniyor...');
+    const statusTimer = setTimeout(() => {
+      setStatus('LinkedIn şirket ve kontak bilgileri analiz ediliyor...');
+    }, 1500);
+    try {
+      const res = await fetch('/analyze', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ website: query })
+      });
+      setStatus('Rapor hazırlanıyor...');
+      const data = await res.json();
+      setResult(data.analysis?.summary || '');
+      setStatus('');
+      clearTimeout(statusTimer);
+    } catch (err) {
+      setStatus('Hata oluştu');
+      clearTimeout(statusTimer);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl p-8 space-y-8">
       <div className="grid gap-8 md:grid-cols-2">
@@ -11,11 +43,17 @@ export default function MainCard() {
           <input
             id="query"
             type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
             className="w-full px-4 py-2 rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500"
             placeholder="example.com or search term"
           />
-          <button className="w-full h-11 bg-blue-900 hover:bg-blue-700 active:bg-blue-800 text-white rounded">
-            Ara
+          <button
+            onClick={handleSearch}
+            className="w-full h-11 bg-blue-900 hover:bg-blue-700 active:bg-blue-800 text-white rounded flex items-center justify-center"
+            disabled={loading}
+          >
+            {loading ? '...' : 'Ara'}
           </button>
         </div>
         <div className="space-y-2">
@@ -31,7 +69,19 @@ export default function MainCard() {
           <p className="text-sm text-slate-400 dark:text-slate-500">Future filters here</p>
         </div>
       </div>
-      <div className="p-4 bg-slate-50 dark:bg-slate-900 rounded-lg shadow-sm h-40" />
+      <div className="p-4 bg-slate-50 dark:bg-slate-900 rounded-lg shadow-sm min-h-40">
+        {loading && (
+          <div className="flex items-center space-x-2">
+            <div className="w-4 h-4 border-2 border-blue-600 border-t-transparent rounded-full animate-spin" />
+            <p className="text-sm text-slate-700 dark:text-slate-300">{status}</p>
+          </div>
+        )}
+        {!loading && result && (
+          <pre className="whitespace-pre-wrap text-sm text-slate-800 dark:text-slate-200">
+            {result}
+          </pre>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add Data Analyst and Orchestrator agents
- implement Brave news search tool
- expose `/analyze` endpoint that chains scraping, LinkedIn and analysis
- update workflows and exports
- add frontend hook to call `/analyze` with progress status
- document new endpoint

## Testing
- `pip install -r backend/requirements.txt`
- `npm install --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_b_687c2f2be93c832f8b3ca76703a273ab