### PR TITLE
Fix search button by proxying API requests

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,11 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173
+    port: 5173,
+    proxy: {
+      '/analyze': 'http://localhost:8000',
+      '/scrape': 'http://localhost:8000',
+      '/find_linkedin': 'http://localhost:8000'
+    }
   }
 });


### PR DESCRIPTION
## Summary
- add Vite dev server proxy so `/analyze`, `/scrape` and `/find_linkedin` requests reach FastAPI backend

## Testing
- `npm install`
- `npm run build`
- `python -m compileall backend`

------
https://chatgpt.com/codex/tasks/task_b_687c33ab2738832fa349a7fd14d11bba