### PR TITLE
Fix environment variable lookup

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -2,8 +2,16 @@
 """Backend package initialization."""
 
 from dotenv import load_dotenv, find_dotenv
+from pathlib import Path
 
-# Load environment variables from a `.env` file if present. This searches up the
-# directory tree starting from the current working directory, allowing the file
-# to reside in the project root.
-load_dotenv(find_dotenv())
+# Load environment variables from a `.env` file if present. The search begins at
+# the current working directory and continues upward so a project root `.env`
+# takes precedence. If nothing is found, fall back to a `.env` located next to
+# this file (i.e. inside the backend package).
+dotenv_path = find_dotenv()
+if not dotenv_path:
+    backend_env = Path(__file__).with_name('.env')
+    if backend_env.exists():
+        dotenv_path = str(backend_env)
+
+load_dotenv(dotenv_path)


### PR DESCRIPTION
## Summary
- look for `.env` in project root, otherwise check backend directory

## Testing
- `pip install -r backend/requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_687c41506a38832f826216b645282203