### PR TITLE
Add company input and sequential scraping flow

### DIFF
--- a/backend/agents/linkedin_agent.py
+++ b/backend/agents/linkedin_agent.py
@@ -16,16 +16,15 @@ def make_prompt(company: str, want_contacts: bool) -> str:
     """Construct the orchestration prompt for GPT-4."""
     return (
         "You are an orchestration agent for the InsightChain platform.\n"
-        "Your goal is:\n"
-        "Given a company name or website, find the most accurate LinkedIn company profile URL.\n"
-        "You have access to these tools:\n"
-        "- linkedinfinder: Finds the correct LinkedIn company page URL from a company name or web address, using web search APIs (Exa, SerpAPI, Brave, Google CSE).\n"
-        "- linkedincontacts: (Optional) Given a LinkedIn company page, extract publicly visible key employees and their positions (uses Playwright scraping).\n\n"
+        "A company name is already provided. Use the given name to locate the most accurate LinkedIn company profile URL.\n"
+        "Tools at your disposal:\n"
+        "- linkedinfinder: search the web and return the LinkedIn company page URL.\n"
+        "- linkedincontacts: (optional) fetch key employees from that page.\n\n"
         "Respond in this JSON format:\n"
         "{\n"
-        "  \"selected_tool\": \"linkedinfinder\",\n"
-        "  \"parameters\": {\n"
-        f"    \"company_name\": \"{company}\"\n"
+        '  "selected_tool": "linkedinfinder",\n'
+        '  "parameters": {\n'
+        f'    "company_name": "{company}"\n'
         "  }\n"
         "}\n"
     )

--- a/backend/agents/orchestrator_agent.py
+++ b/backend/agents/orchestrator_agent.py
@@ -1,6 +1,6 @@
 """Orchestrator agent that runs the full company analysis pipeline."""
 
-from typing import Dict
+from typing import Dict, Optional
 
 from .scraper_agent import orchestrate_scraping
 from .linkedin_agent import orchestrate_linkedin
@@ -8,14 +8,18 @@ from .data_analyst_agent import analyze_data
 from ..utils.logger import logger
 
 
-def run_pipeline(company_url: str) -> Dict[str, object]:
+def run_pipeline(
+    company_url: str, company_name: Optional[str] = None
+) -> Dict[str, object]:
     """Run scraping, LinkedIn enrichment and final analysis."""
     step = "Pipeline"
-    logger.info("%s START: %s", step, company_url)
+    logger.info("%s START: %s %s", step, company_url, company_name)
     try:
         scrape_result = orchestrate_scraping(company_url)
-        linkedin_result = orchestrate_linkedin(company_url, contacts=True)
-        analysis_result = analyze_data(scrape_result, linkedin_result, company_url)
+        if not company_name:
+            company_name = scrape_result.get("company_name", company_url)
+        linkedin_result = orchestrate_linkedin(company_name, contacts=True)
+        analysis_result = analyze_data(scrape_result, linkedin_result, company_name)
         result = {
             "scrape": scrape_result,
             "linkedin": linkedin_result,

--- a/backend/agents/scraper_agent.py
+++ b/backend/agents/scraper_agent.py
@@ -1,4 +1,4 @@
-"""Dynamic scraping agent that selects tools via GPT-4."""
+"""Scraper agent that sequentially tries multiple tools and extracts company info."""
 
 import json
 from typing import Dict
@@ -6,44 +6,20 @@ from typing import Dict
 import openai
 
 from ..utils.logger import logger
+from ..tools import scraping_tools
 
 client = openai.OpenAI()
 
-from ..tools import scraping_tools
 
-
-def make_prompt(company_url: str) -> str:
-    """Construct the decision prompt for GPT-4."""
-    return (
-        "You are an AI orchestration agent for the InsightChain platform.\n"
-        "Your job is to select the most appropriate web scraping tool for a given company website URL based on the site's technology and scraping requirements.\n"
-        "You have access to the following tools:\n"
-        "- staticscraper: For simple, static HTML sites (uses requests + BeautifulSoup)\n"
-        "- jsrender: For modern, JavaScript-rendered pages (uses Playwright)\n"
-        "- formbot: For websites requiring form interaction or automation (uses Selenium)\n"
-        "- masscrawler: For large-scale, multi-page crawling (uses Scrapy)\n"
-        "- llmscraper: For AI-guided or recipe-based scraping (uses ScraperAI or similar)\n\n"
-        f"Analyze the provided website (URL: {company_url}).\n"
-        "Based on its content, structure, and what you can infer from the URL or any quick inspection, select the single most appropriate tool.\n\n"
-        "Respond in this JSON format:\n"
-        "{\n"
-        "  'selected_tool': '<tool_name>',\n"
-        "  'reason': '<why this tool is appropriate>',\n"
-        "  'parameters': {\n"
-        "    'target_url': '{company_url}'\n"
-        "  }\n"
-        "}\n"
+def extract_company_info(html: str) -> Dict[str, str]:
+    """Use GPT-4 to extract company name and a short summary from HTML."""
+    step = "LLM1-ExtractCompany"
+    prompt = (
+        "You are a helpful assistant. Given the HTML of a company's website, "
+        "extract the official company name and provide a one sentence summary.\n\n"
+        f"HTML:\n{html[:4000]}\n\n"
+        "Respond in JSON with keys 'company_name' and 'summary'."
     )
-
-
-def call_gpt4(prompt: str) -> Dict[str, str]:
-    """Call the OpenAI API and return the parsed JSON.
-
-    The GPT-4 model occasionally returns the JSON response wrapped in text
-    or fails to strictly follow the format. To make the agent more robust we
-    try to extract the JSON payload and raise a clear error if parsing fails.
-    """
-    step = "LLM1-ScraperAgent"
     logger.info("%s INPUT: %s", step, prompt)
     try:
         response = client.chat.completions.create(
@@ -67,32 +43,33 @@ def call_gpt4(prompt: str) -> Dict[str, str]:
             raise ValueError(f"Invalid JSON from GPT-4: {content}")
     except Exception as exc:
         logger.exception("%s ERROR: %s", step, exc)
-        raise
+        return {"company_name": "", "summary": ""}
 
 
 def orchestrate_scraping(company_url: str) -> Dict[str, str]:
-    """Main entrypoint for scraping orchestration."""
+    """Attempt multiple scraping tools sequentially and return extracted info."""
     step = "ScraperAgent"
     logger.info("%s INPUT: %s", step, company_url)
-    try:
-        prompt = make_prompt(company_url)
-        decision = call_gpt4(prompt)
-        selected_tool = decision["selected_tool"]
-        params = decision.get("parameters", {})
-        tools_map = {
-            "staticscraper": scraping_tools.staticscraper,
-            "jsrender": scraping_tools.jsrender,
-            "formbot": scraping_tools.formbot,
-            "masscrawler": scraping_tools.masscrawler,
-            "llmscraper": scraping_tools.llmscraper,
-        }
-        tool = tools_map.get(selected_tool)
-        if not tool:
-            raise ValueError(f"Unknown tool selected: {selected_tool}")
-        result = tool(**params)
-        logger.info("%s OUTPUT: %s", step, result)
-        return result
-    except Exception as exc:
-        logger.exception("%s ERROR: %s", step, exc)
-        raise
 
+    tools = [
+        scraping_tools.staticscraper,
+        scraping_tools.jsrender,
+        scraping_tools.formbot,
+        scraping_tools.masscrawler,
+    ]
+    html = ""
+    for tool in tools:
+        try:
+            result = tool(target_url=company_url)
+            html = result.get("html", "")
+            if html:
+                break
+        except Exception as exc:
+            logger.exception("%s %s failed: %s", step, tool.__name__, exc)
+    if not html:
+        raise RuntimeError("All scraping tools failed")
+
+    info = extract_company_info(html)
+    final = {"html": html, **info}
+    logger.info("%s OUTPUT: %s", step, final)
+    return final

--- a/backend/main.py
+++ b/backend/main.py
@@ -35,12 +35,13 @@ def find_linkedin(
 
 class AnalyzeRequest(BaseModel):
     website: str
+    company: str | None = None
 
 
 @app.post("/analyze")
 def analyze(req: AnalyzeRequest):
     """Run the full analysis pipeline for a company website."""
-    result = run_pipeline(req.website)
+    result = run_pipeline(req.website, req.company)
     return result
 
 

--- a/frontend/src/components/MainCard.tsx
+++ b/frontend/src/components/MainCard.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 
 export default function MainCard() {
   const [query, setQuery] = useState('');
+  const [company, setCompany] = useState('');
   const [loading, setLoading] = useState(false);
   const [status, setStatus] = useState('');
   const [result, setResult] = useState('');
@@ -18,7 +19,7 @@ export default function MainCard() {
       const res = await fetch('/analyze', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ website: query })
+        body: JSON.stringify({ website: query, company: company || null })
       });
       setStatus('Rapor hazırlanıyor...');
       const data = await res.json();
@@ -47,6 +48,17 @@ export default function MainCard() {
             onChange={(e) => setQuery(e.target.value)}
             className="w-full px-4 py-2 rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500"
             placeholder="example.com or search term"
+          />
+          <label htmlFor="company" className="block text-slate-800 dark:text-slate-200 font-semibold">
+            Şirket İsmi (opsiyonel)
+          </label>
+          <input
+            id="company"
+            type="text"
+            value={company}
+            onChange={(e) => setCompany(e.target.value)}
+            className="w-full px-4 py-2 rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500"
+            placeholder="Acme Corp"
           />
           <button
             onClick={handleSearch}


### PR DESCRIPTION
## Summary
- add optional company name field in frontend search card
- pass new field to `/analyze` endpoint
- adjust backend to accept `company` and use it throughout pipeline
- change ScraperAgent to run scraping tools sequentially and extract company name
- tweak LinkedInAgent prompt wording

## Testing
- `npm install`
- `npm run build`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687c4c5c92a4832f8542c0b8dc004af6