### PR TITLE
Refactor LinkedIn agent & add URL utils

### DIFF
--- a/backend/agents/linkedin_agent.py
+++ b/backend/agents/linkedin_agent.py
@@ -9,13 +9,7 @@ from ..utils.logger import logger
 
 client = openai.OpenAI()
 
-from ..tools import (
-    linkedinfinder,
-    linkedincontacts,
-    hunterio_lookup,
-    clearbit_lookup,
-    apollo_api,
-)
+
 
 
 def make_prompt(company: str, want_contacts: bool) -> str:
@@ -80,33 +74,14 @@ def call_gpt4(prompt: str) -> Dict[str, str]:
 
 
 def orchestrate_linkedin(company: str, contacts: bool = False) -> Dict[str, object]:
-    """Main entrypoint that orchestrates LinkedIn finding (and optionally contacts)."""
+    """Main entrypoint that returns LinkedIn data extracted by GPT-4."""
     step = "LinkedInAgent"
     logger.info("%s INPUT: %s", step, company)
     try:
         prompt = make_prompt(company, contacts)
-        decision = call_gpt4(prompt)
-        tool_name = decision["selected_tool"]
-        params = decision.get("parameters", {})
-
-        tools_map = {
-            "linkedinfinder": linkedinfinder,
-            "hunterio": hunterio_lookup,
-            "clearbit": clearbit_lookup,
-            "apollo": apollo_api,
-        }
-        if contacts:
-            tools_map["linkedincontacts"] = linkedincontacts
-
-        tool = tools_map.get(tool_name)
-        if not tool:
-            raise ValueError(f"Unknown tool selected: {tool_name}")
-
-        result = tool(**params)
-        if contacts and result.get("linkedin_url"):
-            result.update(linkedincontacts(result["linkedin_url"]))
-        logger.info("%s OUTPUT: %s", step, result)
-        return result
+        linkedin_data = call_gpt4(prompt)
+        logger.info("%s OUTPUT: %s", step, linkedin_data)
+        return linkedin_data
     except Exception as exc:
         logger.exception("%s ERROR: %s", step, exc)
         raise

--- a/backend/agents/scraper_agent.py
+++ b/backend/agents/scraper_agent.py
@@ -6,6 +6,7 @@ from typing import Dict
 import openai
 
 from ..utils.logger import logger
+from ..utils import normalize_url
 from ..tools import scraping_tools
 
 client = openai.OpenAI()
@@ -73,6 +74,7 @@ def extract_company_info(html: str) -> Dict[str, str]:
 def orchestrate_scraping(company_url: str) -> Dict[str, str]:
     """Attempt multiple scraping tools sequentially and return extracted info."""
     step = "ScraperAgent"
+    company_url = normalize_url(company_url)
     logger.info("%s INPUT: %s", step, company_url)
 
     tools = [

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -1,0 +1,15 @@
+"""Utility helpers for the InsightChain backend."""
+
+from __future__ import annotations
+
+
+def normalize_url(url: str) -> str:
+    """Ensure the URL has an HTTP or HTTPS scheme."""
+
+    if not url.startswith("http://") and not url.startswith("https://"):
+        return "https://" + url
+    return url
+
+
+__all__ = ["normalize_url"]
+

--- a/backend/utils/logger.py
+++ b/backend/utils/logger.py
@@ -2,6 +2,8 @@ import logging
 from logging.handlers import RotatingFileHandler
 import os
 
+logging.basicConfig(encoding="utf-8")
+
 LOG_FILE = os.getenv("PIPELINE_LOGFILE", "pipeline.log")
 
 logger = logging.getLogger("pipeline")


### PR DESCRIPTION
## Summary
- handle logging on Windows with utf-8 encoding
- expose `normalize_url` helper
- prepend scheme before scraping
- simplify LinkedIn agent to parse GPT output directly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687cdcb1f024832f83cf8d135a1603d7