### PR TITLE
Add Reporter step for sales-ready output

### DIFF
--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -2,4 +2,5 @@ from .search_agent import run_search
 from .scraper_agent import orchestrate_scraping
 from .linkedin_agent import orchestrate_linkedin
 from .data_analyst_agent import analyze_data
+from .reporter_agent import generate_report
 from .orchestrator_agent import run_pipeline

--- a/backend/agents/orchestrator_agent.py
+++ b/backend/agents/orchestrator_agent.py
@@ -5,6 +5,7 @@ from typing import Dict, Optional
 from .scraper_agent import orchestrate_scraping
 from .linkedin_agent import orchestrate_linkedin
 from .data_analyst_agent import analyze_data
+from .reporter_agent import generate_report
 from ..utils.logger import logger
 
 
@@ -20,10 +21,12 @@ def run_pipeline(
             company_name = scrape_result.get("company_name", company_url)
         linkedin_result = orchestrate_linkedin(company_name, contacts=True)
         analysis_result = analyze_data(scrape_result, linkedin_result, company_name)
+        report_html = generate_report(analysis_result.get("summary", "{}"))
         result = {
             "scrape": scrape_result,
             "linkedin": linkedin_result,
             "analysis": analysis_result,
+            "report": report_html,
         }
         logger.info("%s OUTPUT: %s", step, result)
         return result

--- a/backend/agents/reporter_agent.py
+++ b/backend/agents/reporter_agent.py
@@ -1,0 +1,90 @@
+"""Reporter agent that turns analysis JSON into a polished sales report."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, Any
+
+import openai
+
+from ..utils.logger import logger
+
+client = openai.OpenAI()
+
+
+REPORT_PROMPT = """
+You are an expert sales analyst for Delta Proje, tasked with generating a client-facing report based strictly on structured data from previous analysis.
+DO NOT HALLUCINATE or fabricate any data.
+If a field is missing, clearly state "Information not available."
+
+Your report should be concise, visually appealing, and suitable for direct sharing with sales teams or clients.
+Use clear headlines, bullet points, and strong section formatting.
+
+Report sections:
+
+Company Overview:
+Brief summary (from input)
+Location, sector, company size
+
+Key Decision Makers:
+Names, titles, and short LinkedIn summaries
+
+Growth & Sales Signals:
+Any recent expansion, hiring, or other signals
+
+Delta Proje Sales Opportunities:
+Based on the company's sector and current state, which Delta Proje solutions might fit best?
+Focus on:
+Hydraulic Systems
+Pneumatic Systems
+Process Automation
+AI & Digital Transformation
+Make suggestions only if justified by the input data.
+
+Actionable Recommendations:
+Who to approach, with what value proposition
+Potential entry points or partnership opportunities
+
+Recent News:
+List with links if available
+
+Risks & Open Questions:
+Gaps in data, ambiguities, or competitive risks
+
+Use only information from the provided JSON input.
+Do not make up numbers, projects, or contacts.
+Highlight missing or unclear data directly in the report.
+Output pure HTML suitable for end users.
+"""
+
+
+def make_prompt(analysis: Dict[str, Any]) -> str:
+    """Create Reporter prompt given analysis JSON."""
+    return f"{REPORT_PROMPT}\nInput JSON:\n{json.dumps(analysis, ensure_ascii=False)}"
+
+
+
+def generate_report(analysis_json: str) -> str:
+    """Generate final HTML report from analysis JSON string."""
+    step = "LLM4-Reporter"
+    try:
+        analysis: Dict[str, Any] = json.loads(analysis_json)
+    except json.JSONDecodeError:
+        logger.exception("%s JSON parse error", step)
+        analysis = {}
+
+    prompt = make_prompt(analysis)
+    logger.info("%s INPUT: %s", step, prompt)
+
+    try:
+        response = client.chat.completions.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=1.2,
+        )
+        report = response.choices[0].message.content or ""
+        logger.info("%s OUTPUT: %s", step, report)
+        return report
+    except Exception as exc:
+        logger.exception("%s ERROR: %s", step, exc)
+        raise

--- a/backend/main.py
+++ b/backend/main.py
@@ -42,7 +42,7 @@ class AnalyzeRequest(BaseModel):
 def analyze(req: AnalyzeRequest):
     """Run the full analysis pipeline for a company website."""
     result = run_pipeline(req.website, req.company)
-    return result
+    return {"report": result.get("report", "")}
 
 
 # Future endpoints for agent orchestration will live here.

--- a/frontend/src/components/MainCard.tsx
+++ b/frontend/src/components/MainCard.tsx
@@ -23,7 +23,7 @@ export default function MainCard() {
       });
       setStatus('Rapor hazırlanıyor...');
       const data = await res.json();
-      setResult(data.analysis?.summary || '');
+      setResult(data.report || data.analysis?.summary || '');
       setStatus('');
       clearTimeout(statusTimer);
     } catch (err) {
@@ -89,9 +89,10 @@ export default function MainCard() {
           </div>
         )}
         {!loading && result && (
-          <pre className="whitespace-pre-wrap text-sm text-slate-800 dark:text-slate-200">
-            {result}
-          </pre>
+          <div
+            className="prose dark:prose-invert text-sm"
+            dangerouslySetInnerHTML={{ __html: result }}
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add Reporter agent using GPT-4o to turn JSON analysis into HTML
- integrate Reporter in orchestrator pipeline
- update API `/analyze` to return generated report
- adapt React frontend to display HTML report

## Testing
- `python -m py_compile backend/agents/reporter_agent.py backend/agents/orchestrator_agent.py backend/main.py`
- `npx tsc --noEmit` *(fails: Cannot find module 'react' type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_687ce2e078ec832fbd821dfdcc2db9f6