### PR TITLE
Add SerpAPI and Google CSE search tools

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -25,7 +25,7 @@ Ajanlar, platformun çekirdek işlevlerini modüler şekilde üstlenir. Her ajan
 
 ## 6. Reporter Agent
 - **Görev:** Analiz JSON'unu modern kart tabanlı HTML rapora dönüştürmek
-- **Kullandığı Tool'lar:** newsfinder, linkedin_search, trend_fetcher, product_catalogue, web_search
+- **Kullandığı Tool'lar:** newsfinder, linkedin_search, trend_fetcher, product_catalogue, web_search, serpapi_web_search, google_custom_search
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ npm install
 npm run dev
 ```
 
-Gerekli API anahtarları (Exa, OpenAI ve Brave) için `backend/.env.example` dosyasını kopyalayıp `.env` adıyla doldurmayı unutmayın.
+Gerekli API anahtarları (Exa, OpenAI, Brave, SerpAPI ve Google Custom Search) için `backend/.env.example` dosyasını kopyalayıp `.env` adıyla doldurmayı unutmayın.
 
 LinkedIn şirket sayfasını bulmak için backend'deki `/find_linkedin` endpoint'ini
 kullanabilirsiniz.
 Tam entegre analiz için `/analyze` endpoint'ine şirket web sitesini POST edin.
+Reporter Agent'ın tool destekli çalışmasını görmek için `backend/examples/reporter_usage.py` dosyasını çalıştırabilirsiniz.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,3 +2,6 @@
 EXA_API_KEY=your_exa_api_key_here
 OPENAI_API_KEY=your_openai_api_key_here
 BRAVE_API_KEY=your_brave_api_key_here
+SERPAPI_API_KEY=your_serpapi_key_here
+GOOGLE_API_KEY=your_google_api_key_here
+GOOGLE_CSE_ID=your_cse_id_here

--- a/backend/examples/reporter_usage.py
+++ b/backend/examples/reporter_usage.py
@@ -1,0 +1,6 @@
+from backend.agents.reporter_agent import generate_report
+
+if __name__ == "__main__":
+    sample_json = '{"company_summary": "Test", "decision_makers": []}'
+    html = generate_report(sample_json, tool_mode=True)
+    print(html[:200])  # print first 200 chars

--- a/backend/tests/test_tools.py
+++ b/backend/tests/test_tools.py
@@ -1,0 +1,28 @@
+import os
+import unittest
+from backend.tools.search_tools import serpapi_search, google_cse_search
+
+class ToolEnvTest(unittest.TestCase):
+    def test_serpapi_requires_key(self):
+        env_var = os.environ.pop("SERPAPI_API_KEY", None)
+        try:
+            with self.assertRaises(ValueError):
+                serpapi_search("OpenAI")
+        finally:
+            if env_var is not None:
+                os.environ["SERPAPI_API_KEY"] = env_var
+
+    def test_google_cse_requires_keys(self):
+        key = os.environ.pop("GOOGLE_API_KEY", None)
+        cse = os.environ.pop("GOOGLE_CSE_ID", None)
+        try:
+            with self.assertRaises(ValueError):
+                google_cse_search("OpenAI")
+        finally:
+            if key is not None:
+                os.environ["GOOGLE_API_KEY"] = key
+            if cse is not None:
+                os.environ["GOOGLE_CSE_ID"] = cse
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tools/__init__.py
+++ b/backend/tools/__init__.py
@@ -13,6 +13,8 @@ from .search_tools import (
     google_search,
     duckduckgo_search,
     company_api_search,
+    serpapi_search,
+    google_cse_search,
 )
 from .enrichment_tools import (
     hunterio_lookup,
@@ -25,4 +27,6 @@ from .insight_tools import (
     trend_fetcher,
     product_catalogue,
     web_search,
+    serpapi_web_search,
+    google_custom_search,
 )

--- a/backend/tools/insight_tools.py
+++ b/backend/tools/insight_tools.py
@@ -2,7 +2,13 @@ from typing import Dict, List
 
 from .linkedin_finder import linkedinfinder
 from .news_search import brave_news
-from .search_tools import bing_search, google_search, duckduckgo_search
+from .search_tools import (
+    bing_search,
+    google_search,
+    duckduckgo_search,
+    serpapi_search,
+    google_cse_search,
+)
 
 
 def linkedin_search(company: str) -> Dict[str, str]:
@@ -32,3 +38,13 @@ def web_search(query: str) -> Dict[str, List[str]]:
     results.extend(google_search(query))
     results.extend(duckduckgo_search(query))
     return {"results": results}
+
+
+def serpapi_web_search(query: str) -> Dict[str, List[Dict[str, str]]]:
+    """Search the web via SerpAPI."""
+    return {"results": serpapi_search(query)}
+
+
+def google_custom_search(query: str) -> Dict[str, List[Dict[str, str]]]:
+    """Search using Google Custom Search API."""
+    return {"results": google_cse_search(query)}

--- a/backend/tools/search_tools.py
+++ b/backend/tools/search_tools.py
@@ -1,4 +1,7 @@
-from typing import List
+from typing import Dict, List
+
+import os
+import requests
 
 
 def bing_search(query: str) -> List[str]:
@@ -19,3 +22,42 @@ def duckduckgo_search(query: str) -> List[str]:
 def company_api_search(query: str) -> List[str]:
     """Placeholder Company API search"""
     return [f"Company API result for {query}"]
+
+
+SERPAPI_API_KEY = os.getenv("SERPAPI_API_KEY")
+SERPAPI_URL = "https://serpapi.com/search"
+
+
+def serpapi_search(query: str) -> List[Dict[str, str]]:
+    """Search the web using SerpAPI and return the first few results."""
+    if not SERPAPI_API_KEY:
+        raise ValueError("SERPAPI_API_KEY not set")
+
+    params = {"engine": "google", "q": query, "api_key": SERPAPI_API_KEY, "num": 3}
+    resp = requests.get(SERPAPI_URL, params=params, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    results: List[Dict[str, str]] = []
+    for item in data.get("organic_results", [])[:3]:
+        results.append({"title": item.get("title", ""), "url": item.get("link", "")})
+    return results
+
+
+GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
+GOOGLE_CSE_ID = os.getenv("GOOGLE_CSE_ID")
+GOOGLE_CSE_URL = "https://www.googleapis.com/customsearch/v1"
+
+
+def google_cse_search(query: str) -> List[Dict[str, str]]:
+    """Search using Google Custom Search API."""
+    if not GOOGLE_API_KEY or not GOOGLE_CSE_ID:
+        raise ValueError("GOOGLE_API_KEY or GOOGLE_CSE_ID not set")
+
+    params = {"key": GOOGLE_API_KEY, "cx": GOOGLE_CSE_ID, "q": query}
+    resp = requests.get(GOOGLE_CSE_URL, params=params, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    results: List[Dict[str, str]] = []
+    for item in data.get("items", [])[:3]:
+        results.append({"title": item.get("title", ""), "url": item.get("link", "")})
+    return results


### PR DESCRIPTION
## Summary
- extend Reporter Agent prompt with tool usage guidance
- support serpapi and Google Custom Search tools
- expose new search utilities in `insight_tools`
- document new Reporter Agent capabilities
- show example usage and provide simple unit tests
- update environment variables and README instructions

## Testing
- `pip install -r backend/requirements.txt`
- `OPENAI_API_KEY=dummy python -m unittest discover backend/tests`

------
https://chatgpt.com/codex/tasks/task_b_687ceba74914832f8282bce20a3fe065