### PR TITLE
Fix reporter tool call handling

### DIFF
--- a/backend/agents/reporter_agent.py
+++ b/backend/agents/reporter_agent.py
@@ -163,6 +163,8 @@ def generate_report(analysis_json: str, tool_mode: bool = False) -> str:
                 tools=tools if tool_mode else None,
             )
             msg = response.choices[0].message
+            # always append assistant message so tool replies have context
+            messages.append(msg.model_dump())
             if msg.content:
                 report = msg.content
                 logger.info("%s OUTPUT: %s", step, report)


### PR DESCRIPTION
## Summary
- append assistant response when Reporter Agent handles tool calls
- ensure tool messages reference preceding tool_call

## Testing
- `pip install -r backend/requirements.txt`
- `OPENAI_API_KEY=dummy PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687cee99b2a8832f9ddbfb5c8711b33f