### PR TITLE
Implement connectivity check before running analysis

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, Query
 from pydantic import BaseModel
+import socket
 
 from .agents import (
     orchestrate_scraping,
@@ -8,6 +9,27 @@ from .agents import (
 )
 
 app = FastAPI(title="InsightChain API")
+
+
+def check_port_443(host: str = "google.com") -> bool:
+    """Return True if a TCP connection to host:443 succeeds."""
+    try:
+        with socket.create_connection((host, 443), timeout=3):
+            return True
+    except OSError:
+        return False
+
+
+@app.get("/check_internet")
+def check_internet():
+    """Check outbound HTTPS connectivity."""
+    for host in ("google.com", "api.serpapi.com", "www.bing.com"):
+        if check_port_443(host):
+            return {"ok": True}
+    return {
+        "ok": False,
+        "error": "İNTERNET BAĞLANTISI KURULAMADI. Lütfen bağlantınızı kontrol edin ve 443 portuna erişimin açık olduğuna emin olun",
+    }
 
 
 @app.get("/")

--- a/frontend/src/components/MainCard.tsx
+++ b/frontend/src/components/MainCard.tsx
@@ -11,6 +11,20 @@ export default function MainCard() {
     if (!query) return;
     setLoading(true);
     setResult('');
+    setStatus('İnternet bağlantısı kontrol ediliyor...');
+    try {
+      const ping = await fetch('/check_internet');
+      const pingRes = await ping.json();
+      if (!pingRes.ok) {
+        setStatus(pingRes.error);
+        setLoading(false);
+        return;
+      }
+    } catch (err) {
+      setStatus('İNTERNET BAĞLANTISI KURULAMADI. Lütfen bağlantınızı kontrol edin ve 443 portuna erişimin açık olduğuna emin olun');
+      setLoading(false);
+      return;
+    }
     setStatus('Web sitesi inceleniyor...');
     const statusTimer = setTimeout(() => {
       setStatus('LinkedIn şirket ve kontak bilgileri analiz ediliyor...');


### PR DESCRIPTION
## Summary
- add `/check_internet` endpoint for TCP connectivity tests
- call new endpoint from the UI before running `/analyze`

## Testing
- `pytest backend/tests/test_tools.py -q`

------
https://chatgpt.com/codex/tasks/task_b_687d0c48fc80832fae6ea11ab5b5dccb