### PR TITLE
Add error popup for connectivity check

### DIFF
--- a/frontend/src/components/ConnectionPopup.tsx
+++ b/frontend/src/components/ConnectionPopup.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+
+interface Props {
+  onRetry: () => Promise<boolean>;
+  onClose: () => void;
+}
+
+export default function ConnectionPopup({ onRetry, onClose }: Props) {
+  const [showHelp, setShowHelp] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  const handleRetry = async () => {
+    const ok = await onRetry();
+    if (ok) {
+      setSuccess(true);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <div className="bg-white dark:bg-slate-800 p-6 rounded-lg shadow-lg max-w-md text-slate-900 dark:text-white space-y-4">
+        {!success && (
+          <>
+            <p>
+              İNTERNET BAĞLANTISI KURULAMADI.<br />
+              Lütfen bağlantınızı kontrol edin ve 443 portuna erişimin açık olduğuna emin olun.
+            </p>
+            {showHelp && (
+              <div className="text-sm space-y-2">
+                <p>
+                  İnternetinizin aktif olup olmadığını kontrol edin.<br />
+                  • Tarayıcınızdan herhangi bir web sitesine (\u00f6rn. google.com, cnn.com) erişebiliyor musunuz?
+                </p>
+                <p>
+                  Güvenlik Duvarı, Proxy veya VPN engeline takılmış olabilirsiniz.<br />
+                  • Kurumsal ağdaysanız, IT departmanınıza danışın.<br />
+                  • VPN, Proxy veya Antivirüs programları 443 portunu engelliyor olabilir.
+                </p>
+                <p>
+                  443 portuna erişiminiz var mı?<br />
+                  • 443 portu genellikle “güvenli (https)” bağlantılar için gereklidir.<br />
+                  • Ağınızda ekstra bir firewall/antivirüs yazılımı varsa, bu portu engellemediğinden emin olun.
+                </p>
+                <p>
+                  Yine de sorun devam ederse:<br />
+                  • Bilgisayarınızı ve modem/router'ınızı yeniden başlatın.<br />
+                  • Farklı bir ağdan (mobil hotspot, başka Wi-Fi) tekrar deneyin.<br />
+                  • Detaylı destek için IT desteğiyle iletişime geçin.
+                </p>
+                <p>Gerekirse sistem yöneticinizle iletişime geçin.</p>
+              </div>
+            )}
+            <div className="flex justify-between items-center pt-2">
+              <button onClick={() => setShowHelp((v) => !v)} className="text-blue-700 underline text-sm">
+                Yardım
+              </button>
+              <button onClick={handleRetry} className="px-3 py-1 bg-blue-900 text-white rounded">
+                Tekrar Dene
+              </button>
+            </div>
+          </>
+        )}
+        {success && (
+          <div className="space-y-4">
+            <p>✅ Bağlantı başarılı. Pencereyi kapatıp işlemlerinize devam edebilirsiniz.</p>
+            <div className="flex justify-end">
+              <button onClick={onClose} className="px-3 py-1 bg-blue-900 text-white rounded">
+                Kapat
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/MainCard.tsx
+++ b/frontend/src/components/MainCard.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import ConnectionPopup from './ConnectionPopup';
 
 export default function MainCard() {
   const [query, setQuery] = useState('');
@@ -6,23 +7,28 @@ export default function MainCard() {
   const [loading, setLoading] = useState(false);
   const [status, setStatus] = useState('');
   const [result, setResult] = useState('');
+  const [showPopup, setShowPopup] = useState(false);
+
+  const checkInternet = async () => {
+    try {
+      const ping = await fetch('/check_internet');
+      const pingRes = await ping.json();
+      return Boolean(pingRes.ok);
+    } catch {
+      return false;
+    }
+  };
 
   const handleSearch = async () => {
     if (!query) return;
     setLoading(true);
     setResult('');
     setStatus('İnternet bağlantısı kontrol ediliyor...');
-    try {
-      const ping = await fetch('/check_internet');
-      const pingRes = await ping.json();
-      if (!pingRes.ok) {
-        setStatus(pingRes.error);
-        setLoading(false);
-        return;
-      }
-    } catch (err) {
-      setStatus('İNTERNET BAĞLANTISI KURULAMADI. Lütfen bağlantınızı kontrol edin ve 443 portuna erişimin açık olduğuna emin olun');
+    const ok = await checkInternet();
+    if (!ok) {
       setLoading(false);
+      setStatus('');
+      setShowPopup(true);
       return;
     }
     setStatus('Web sitesi inceleniyor...');
@@ -49,7 +55,13 @@ export default function MainCard() {
   };
 
   return (
-    <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl p-8 space-y-8">
+    <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl p-8 space-y-8 relative">
+      {showPopup && (
+        <ConnectionPopup
+          onRetry={checkInternet}
+          onClose={() => setShowPopup(false)}
+        />
+      )}
       <div className="grid gap-8 md:grid-cols-2">
         <div className="space-y-4">
           <label htmlFor="query" className="block text-slate-800 dark:text-slate-200 font-semibold">


### PR DESCRIPTION
## Summary
- add `ConnectionPopup` component to show retryable internet error
- integrate popup into `MainCard` when port 443 check fails

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687d0ed02f28832f9300f5b5d0d4044a