### PR TITLE
Fix connection check in frontend proxy

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
     proxy: {
       '/analyze': 'http://localhost:8000',
       '/scrape': 'http://localhost:8000',
-      '/find_linkedin': 'http://localhost:8000'
+      '/find_linkedin': 'http://localhost:8000',
+      '/check_internet': 'http://localhost:8000'
     }
   }
 });


### PR DESCRIPTION
## Summary
- proxy `/check_internet` to backend in Vite config

## Testing
- `pip install -r backend/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687d1282480c832f931f157c01b93dee