### PR TITLE
Implement real search agent

### DIFF
--- a/backend/agents/search_agent.py
+++ b/backend/agents/search_agent.py
@@ -1,22 +1,20 @@
 """Temel Search Agent.
 Bu ajan verilen anahtar kelimeler için örnek veri döner."""
 
-from typing import List
+from typing import List, Dict
 
-from ..tools import (
-    bing_search,
-    google_search,
-    duckduckgo_search,
-    company_api_search,
+from ..tools.search_tools import (
+    serpapi_search,
+    brave_search,
+    google_cse_search,
 )
 
 
-def run_search(keywords: List[str]) -> List[str]:
+def run_search(keywords: List[str]) -> List[Dict[str, str]]:
     """Aggregate results from multiple search tools."""
-    results: List[str] = []
+    results: List[Dict[str, str]] = []
     for kw in keywords:
-        results.extend(bing_search(kw))
-        results.extend(google_search(kw))
-        results.extend(duckduckgo_search(kw))
-        results.extend(company_api_search(kw))
+        results.extend(serpapi_search(kw))
+        results.extend(brave_search(kw))
+        results.extend(google_cse_search(kw))
     return results

--- a/backend/tests/test_tools.py
+++ b/backend/tests/test_tools.py
@@ -1,10 +1,27 @@
 import os
+import sys
 import unittest
-from backend.tools.search_tools import (
-    serpapi_search,
-    google_cse_search,
-    brave_search,
-)
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+# Provide a dummy OpenAI key to avoid import errors
+# Ensure project root is on sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1].parent))
+
+# Provide a dummy OpenAI key to avoid import errors
+os.environ.setdefault("OPENAI_API_KEY", "test")
+# Load search_tools without triggering backend.tools __init__
+search_tools_path = Path(__file__).resolve().parents[1] / "tools" / "search_tools.py"
+spec = importlib.util.spec_from_file_location("search_tools", search_tools_path)
+search_tools = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(search_tools)
+
+serpapi_search = search_tools.serpapi_search
+google_cse_search = search_tools.google_cse_search
+brave_search = search_tools.brave_search
+
+from backend.agents.search_agent import run_search
 
 
 class ToolEnvTest(unittest.TestCase):
@@ -37,6 +54,27 @@ class ToolEnvTest(unittest.TestCase):
         finally:
             if key is not None:
                 os.environ["BRAVE_API_KEY"] = key
+
+
+class SearchAgentTest(unittest.TestCase):
+    @patch("backend.agents.search_agent.google_cse_search")
+    @patch("backend.agents.search_agent.brave_search")
+    @patch("backend.agents.search_agent.serpapi_search")
+    def test_run_search_aggregates_results(self, mock_serpapi, mock_brave, mock_google):
+        mock_serpapi.return_value = [{"title": "serp"}]
+        mock_brave.return_value = [{"title": "brave"}]
+        mock_google.return_value = [{"title": "google"}]
+
+        results = run_search(["openai"])
+
+        self.assertEqual(
+            results,
+            [
+                {"title": "serp"},
+                {"title": "brave"},
+                {"title": "google"},
+            ],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- integrate serpapi_search, brave_search and google_cse_search in search agent
- aggregate search results sequentially
- update tests to use new search agent logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687d47a70c0c832fad67f684fe415075