### PR TITLE
Add iterative enhanced search loop

### DIFF
--- a/backend/agents/data_analyst_agent.py
+++ b/backend/agents/data_analyst_agent.py
@@ -1,7 +1,7 @@
 """Data Analyst Agent that creates a final company report."""
 
 import json
-from typing import Dict
+from typing import Dict, List, Optional
 
 import openai
 
@@ -16,6 +16,7 @@ def make_prompt(
     scrape_data: Dict[str, str],
     linkedin_data: Dict[str, object],
     news_data: Dict[str, object],
+    extra_search: Optional[List[Dict[str, str]]] = None,
 ) -> str:
     """Construct the Data Analyst Agent prompt."""
     return (
@@ -52,12 +53,16 @@ def make_prompt(
         "\n"
         f"Scraper Output (JSON): {json.dumps(scrape_data)[:1000]}\n"
         f"LinkedIn Output (JSON): {json.dumps(linkedin_data)[:1000]}\n"
-        f"News (JSON): {json.dumps(news_data)[:1000]}"
+        f"News (JSON): {json.dumps(news_data)[:1000]}\n"
+        f"Extra Search Results (JSON): {json.dumps(extra_search or [])[:1000]}"
     )
 
 
 def analyze_data(
-    scrape_data: Dict[str, str], linkedin_data: Dict[str, object], query: str
+    scrape_data: Dict[str, str],
+    linkedin_data: Dict[str, object],
+    query: str,
+    extra_search: Optional[List[Dict[str, str]]] = None,
 ) -> Dict[str, str]:
     """Run the Data Analyst agent and return final summary."""
     step = "LLM3-DataAnalystAgent"
@@ -66,7 +71,7 @@ def analyze_data(
     except Exception:
         news_data = {"news": []}
 
-    prompt = make_prompt(scrape_data, linkedin_data, news_data)
+    prompt = make_prompt(scrape_data, linkedin_data, news_data, extra_search)
     logger.info("%s INPUT: %s", step, prompt)
     try:
         response = client.chat.completions.create(

--- a/backend/agents/enhanced_search_agent.py
+++ b/backend/agents/enhanced_search_agent.py
@@ -1,0 +1,23 @@
+from typing import List, Dict
+
+from .search_agent import run_search
+
+# Mapping from missing field names to search query fragments
+QUERY_MAP = {
+    "foundation": ["foundation year", "established"],
+    "production_capacity": ["production capacity"],
+    "r_and_d": ["R&D investment", "research and development"],
+    "references": ["customer references", "case studies"],
+    "decision_makers": ["leadership team", "executives"],
+    "growth_signals": ["growth signals", "investment", "expansion", "hiring"],
+}
+
+
+def targeted_search(company: str, topics: List[str]) -> List[Dict[str, str]]:
+    """Run enhanced search queries for given topics about the company."""
+    queries: List[str] = []
+    for topic in topics:
+        fragments = QUERY_MAP.get(topic, [topic])
+        for frag in fragments:
+            queries.append(f"{company} {frag}")
+    return run_search(queries)

--- a/backend/agents/orchestrator_agent.py
+++ b/backend/agents/orchestrator_agent.py
@@ -1,10 +1,13 @@
 """Orchestrator agent that runs the full company analysis pipeline."""
 
 from typing import Dict, Optional
+import json
+import time
 
 from .scraper_agent import orchestrate_scraping
 from .linkedin_agent import orchestrate_linkedin
 from .data_analyst_agent import analyze_data
+from .enhanced_search_agent import targeted_search
 from .reporter_agent import generate_report
 from ..utils.logger import logger
 
@@ -21,6 +24,43 @@ def run_pipeline(
             company_name = scrape_result.get("company_name", company_url)
         linkedin_result = orchestrate_linkedin(company_name, contacts=True)
         analysis_result = analyze_data(scrape_result, linkedin_result, company_name)
+
+        # Check for missing fields and retry with enhanced search if needed
+        max_retries = 3
+        retries = 0
+        while True:
+            try:
+                summary_data = json.loads(analysis_result.get("summary", "{}"))
+            except json.JSONDecodeError:
+                summary_data = {}
+            missing = [
+                field
+                for field in [
+                    "foundation",
+                    "production_capacity",
+                    "r_and_d",
+                    "references",
+                    "decision_makers",
+                    "growth_signals",
+                ]
+                if not summary_data.get(field)
+            ]
+            if not missing or retries >= max_retries:
+                break
+            iter_start = time.perf_counter()
+            search_results = targeted_search(company_name, missing)
+            analysis_result = analyze_data(
+                scrape_result,
+                linkedin_result,
+                company_name,
+                search_results,
+            )
+            duration = time.perf_counter() - iter_start
+            logger.info(
+                "%s RETRY %s duration %.2fs", step, retries + 1, duration
+            )
+            retries += 1
+
         report_html = generate_report(analysis_result.get("summary", "{}"), tool_mode=True)
         result = {
             "scrape": scrape_result,


### PR DESCRIPTION
## Summary
- extend Data Analyst agent to accept extra search results
- add enhanced search agent for targeted queries
- retry analysis with enhanced search until all key fields populated or max retries hit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687d49135cd4832f8c3ae48c5452505b