### PR TITLE
Add crawler to scraper agent

### DIFF
--- a/backend/agents/scraper_agent.py
+++ b/backend/agents/scraper_agent.py
@@ -1,7 +1,12 @@
 """Scraper agent that sequentially tries multiple tools and extracts company info."""
 
 import json
-from typing import Dict
+from typing import Dict, List, Set, Tuple
+
+import requests
+from bs4 import BeautifulSoup
+from urllib.parse import urlparse, urljoin
+from urllib.robotparser import RobotFileParser
 
 import openai
 
@@ -10,6 +15,62 @@ from ..utils import normalize_url
 from ..tools import scraping_tools
 
 client = openai.OpenAI()
+
+
+def crawl_site(start_url: str, depth: int = 1) -> str:
+    """Crawl internal links under the same domain up to ``depth``.
+
+    The crawler respects robots.txt. Network errors are logged and skipped.
+    Returns the concatenated HTML of all fetched pages.
+    """
+
+    step = "ScraperAgent.crawl_site"
+    start_url = normalize_url(start_url)
+    parsed = urlparse(start_url)
+    base = f"{parsed.scheme}://{parsed.netloc}"
+
+    rp = RobotFileParser()
+    rp.set_url(urljoin(base, "/robots.txt"))
+    try:
+        rp.read()
+    except Exception as exc:  # robots.txt may not exist or not be reachable
+        logger.warning("%s robots.txt unavailable: %s", step, exc)
+        rp = None
+
+    visited: Set[str] = set()
+    queue: List[Tuple[str, int]] = [(start_url, 0)]
+    html_parts: List[str] = []
+
+    while queue:
+        url, level = queue.pop(0)
+        if url in visited or level > depth:
+            continue
+        visited.add(url)
+        path = urlparse(url).path or "/"
+        if rp and not rp.can_fetch("*", path):
+            logger.info("%s blocked by robots.txt: %s", step, url)
+            continue
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+        except Exception as exc:
+            logger.warning("%s failed to fetch %s: %s", step, url, exc)
+            continue
+
+        html_parts.append(resp.text)
+
+        if level == depth:
+            continue
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+        for link in soup.find_all("a", href=True):
+            joined = urljoin(url, link["href"])
+            link_parsed = urlparse(joined)
+            if link_parsed.scheme in {"http", "https"} and link_parsed.netloc == parsed.netloc:
+                if joined not in visited:
+                    queue.append((joined, level + 1))
+
+    return "\n".join(html_parts)
 
 
 def extract_company_info(html: str) -> Dict[str, str]:
@@ -71,8 +132,12 @@ def extract_company_info(html: str) -> Dict[str, str]:
         }
 
 
-def orchestrate_scraping(company_url: str) -> Dict[str, str]:
-    """Attempt multiple scraping tools sequentially and return extracted info."""
+def orchestrate_scraping(company_url: str, depth_limit: int = 0) -> Dict[str, str]:
+    """Attempt multiple scraping tools sequentially and crawl internal pages.
+
+    ``depth_limit`` controls how deep the internal crawler should go. ``0``
+    disables crawling and only fetches the main page.
+    """
     step = "ScraperAgent"
     company_url = normalize_url(company_url)
     logger.info("%s INPUT: %s", step, company_url)
@@ -95,6 +160,14 @@ def orchestrate_scraping(company_url: str) -> Dict[str, str]:
             logger.exception("%s %s failed: %s", step, tool.__name__, exc)
     if not html:
         raise RuntimeError("All scraping tools failed")
+
+    if depth_limit > 0:
+        try:
+            crawl_html = crawl_site(company_url, depth_limit)
+            if crawl_html:
+                html = f"{html}\n{crawl_html}"
+        except Exception as exc:
+            logger.warning("%s crawl_site failed: %s", step, exc)
 
     info = extract_company_info(html)
     final = {"html": html, **info}

--- a/backend/tests/test_scraper_agent.py
+++ b/backend/tests/test_scraper_agent.py
@@ -1,0 +1,97 @@
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch, Mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1].parent))
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+# Provide dummy modules for heavy scraping dependencies
+sys.modules.setdefault("playwright", types.ModuleType("playwright"))
+playwright_sync = types.ModuleType("playwright.sync_api")
+playwright_sync.sync_playwright = lambda: None
+sys.modules.setdefault("playwright.sync_api", playwright_sync)
+
+selenium_module = types.ModuleType("selenium")
+webdriver_module = types.ModuleType("selenium.webdriver")
+chrome_module = types.ModuleType("selenium.webdriver.chrome")
+chrome_options_module = types.ModuleType("selenium.webdriver.chrome.options")
+webdriver_module.Chrome = lambda options=None: types.SimpleNamespace(get=lambda x: None, page_source="", quit=lambda: None)
+chrome_options_module.Options = object
+selenium_module.webdriver = webdriver_module
+webdriver_module.chrome = chrome_module
+chrome_module.options = chrome_options_module
+sys.modules.setdefault("selenium", selenium_module)
+sys.modules.setdefault("selenium.webdriver", webdriver_module)
+sys.modules.setdefault("selenium.webdriver.chrome", chrome_module)
+sys.modules.setdefault("selenium.webdriver.chrome.options", chrome_options_module)
+
+scrapy_module = types.ModuleType("scrapy")
+crawler_module = types.ModuleType("scrapy.crawler")
+crawler_module.CrawlerProcess = object
+scrapy_module.Spider = object
+sys.modules.setdefault("scrapy", scrapy_module)
+sys.modules.setdefault("scrapy.crawler", crawler_module)
+
+from backend.agents.scraper_agent import crawl_site
+
+
+class CrawlSiteTests(unittest.TestCase):
+    @patch("backend.agents.scraper_agent.requests.get")
+    @patch("backend.agents.scraper_agent.RobotFileParser")
+    def test_collects_internal_links(self, mock_rfp_cls, mock_get):
+        mock_rfp = mock_rfp_cls.return_value
+        mock_rfp.read.return_value = None
+        mock_rfp.can_fetch.return_value = True
+
+        html_index = '<html><a href="/about">About</a></html>'
+        html_about = '<html>About us</html>'
+
+        def side_effect(url, timeout=10):
+            resp = Mock()
+            resp.raise_for_status.return_value = None
+            resp.text = html_about if url.endswith("/about") else html_index
+            return resp
+
+        mock_get.side_effect = side_effect
+
+        result = crawl_site("http://example.com", depth=1)
+        self.assertIn(html_index, result)
+        self.assertIn(html_about, result)
+        self.assertEqual(mock_get.call_count, 2)
+
+    @patch("backend.agents.scraper_agent.requests.get")
+    @patch("backend.agents.scraper_agent.RobotFileParser")
+    def test_depth_limit(self, mock_rfp_cls, mock_get):
+        mock_rfp = mock_rfp_cls.return_value
+        mock_rfp.read.return_value = None
+        mock_rfp.can_fetch.return_value = True
+
+        html_index = '<html><a href="/a">A</a></html>'
+        html_a = '<html><a href="/b">B</a></html>'
+        html_b = '<html>Deep</html>'
+
+        def side_effect(url, timeout=10):
+            resp = Mock()
+            resp.raise_for_status.return_value = None
+            if url.endswith('/b'):
+                resp.text = html_b
+            elif url.endswith('/a'):
+                resp.text = html_a
+            else:
+                resp.text = html_index
+            return resp
+
+        mock_get.side_effect = side_effect
+
+        result = crawl_site("http://example.com", depth=1)
+        self.assertIn(html_index, result)
+        self.assertIn(html_a, result)
+        self.assertNotIn(html_b, result)
+        self.assertEqual(mock_get.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend scraper_agent with a site crawler that aggregates HTML from internal links
- respect robots.txt and handle errors while crawling
- concatenate crawled HTML before extracting company info
- add unit tests verifying URL collection and depth control

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687d4a1d1528832f8008144375585a66