### PR TITLE
Add timing metrics for agents

### DIFF
--- a/backend/agents/linkedin_agent.py
+++ b/backend/agents/linkedin_agent.py
@@ -4,6 +4,7 @@ Ajan asla içerik uydurmaz, sadece harici API araması sonucu veri döndürür.
 """
 
 from typing import Dict, List
+import time
 
 from ..utils.logger import logger
 from ..tools.search_tools import serpapi_search, brave_search, google_cse_search
@@ -53,6 +54,7 @@ def orchestrate_linkedin(company: str, contacts: bool = False) -> Dict[str, obje
     """Find LinkedIn info using external search engines only."""
     step = "LinkedInAgent"
     logger.info("%s INPUT: %s", step, company)
+    start = time.perf_counter()
 
     query = f"site:linkedin.com/in OR site:linkedin.com/company {company}"
     search_results = _search_all(query)
@@ -81,5 +83,7 @@ def orchestrate_linkedin(company: str, contacts: bool = False) -> Dict[str, obje
         "search_results": search_results,
         "note": note,
     }
-    logger.info("%s OUTPUT: %s", step, result)
+    duration_ms = int((time.perf_counter() - start) * 1000)
+    result["duration_ms"] = duration_ms
+    logger.info("%s OUTPUT (%d ms): %s", step, duration_ms, result)
     return result

--- a/backend/agents/reporter_agent.py
+++ b/backend/agents/reporter_agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from typing import Any, Dict
+import time
 
 import openai
 
@@ -96,6 +97,7 @@ def generate_report(analysis_json: str, tool_mode: bool = False) -> str:
     final HTML content.
     """
     step = "LLM4-Reporter"
+    start = time.perf_counter()
     try:
         analysis: Dict[str, Any] = json.loads(analysis_json)
     except json.JSONDecodeError:
@@ -178,8 +180,9 @@ def generate_report(analysis_json: str, tool_mode: bool = False) -> str:
             messages.append(msg.model_dump())
             if msg.content:
                 report = msg.content
-                logger.info("%s OUTPUT: %s", step, report)
-                return report
+                duration_ms = int((time.perf_counter() - start) * 1000)
+                logger.info("%s OUTPUT (%d ms): %s", step, duration_ms, report)
+                return {"html": report, "duration_ms": duration_ms}
             for call in msg.tool_calls or []:
                 try:
                     args = json.loads(call.function.arguments or "{}")

--- a/backend/agents/scraper_agent.py
+++ b/backend/agents/scraper_agent.py
@@ -2,6 +2,7 @@
 
 import json
 from typing import Dict, List, Set, Tuple
+import time
 
 import requests
 from bs4 import BeautifulSoup
@@ -141,6 +142,7 @@ def orchestrate_scraping(company_url: str, depth_limit: int = 0) -> Dict[str, st
     step = "ScraperAgent"
     company_url = normalize_url(company_url)
     logger.info("%s INPUT: %s", step, company_url)
+    start = time.perf_counter()
 
     tools = [
         scraping_tools.staticscraper,
@@ -170,6 +172,7 @@ def orchestrate_scraping(company_url: str, depth_limit: int = 0) -> Dict[str, st
             logger.warning("%s crawl_site failed: %s", step, exc)
 
     info = extract_company_info(html)
-    final = {"html": html, **info}
-    logger.info("%s OUTPUT: %s", step, final)
+    duration_ms = int((time.perf_counter() - start) * 1000)
+    final = {"html": html, **info, "duration_ms": duration_ms}
+    logger.info("%s OUTPUT (%d ms): %s", step, duration_ms, final)
     return final

--- a/backend/examples/reporter_usage.py
+++ b/backend/examples/reporter_usage.py
@@ -2,5 +2,5 @@ from backend.agents.reporter_agent import generate_report
 
 if __name__ == "__main__":
     sample_json = '{"company_summary": "Test", "decision_makers": []}'
-    html = generate_report(sample_json, tool_mode=True)
-    print(html[:200])  # print first 200 chars
+    report = generate_report(sample_json, tool_mode=True)
+    print(report["html"][:200])  # print first 200 chars

--- a/backend/main.py
+++ b/backend/main.py
@@ -64,7 +64,7 @@ class AnalyzeRequest(BaseModel):
 def analyze(req: AnalyzeRequest):
     """Run the full analysis pipeline for a company website."""
     result = run_pipeline(req.website, req.company)
-    return {"report": result.get("report", "")}
+    return result
 
 
 # Future endpoints for agent orchestration will live here.

--- a/backend/tests/test_timings.py
+++ b/backend/tests/test_timings.py
@@ -1,0 +1,22 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1].parent))
+
+from backend.agents.linkedin_agent import orchestrate_linkedin
+
+
+class DurationLoggingTest(unittest.TestCase):
+    @patch("backend.agents.linkedin_agent.logger.info")
+    @patch("backend.agents.linkedin_agent._search_all")
+    def test_duration_logged(self, mock_search, mock_log):
+        mock_search.return_value = {"serpapi": [], "brave": [], "google": []}
+        orchestrate_linkedin("acme", contacts=False)
+        output_call = [c for c in mock_log.call_args_list if "OUTPUT" in c.args[0]][0]
+        self.assertIsInstance(output_call.args[2], int)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- measure execution time in scraper, LinkedIn, data analyst and reporter agents
- include duration in logger output and return dictionaries
- expose step timings via pipeline and API
- update reporter example
- test log duration formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687d4b6197ac832fac6985df5763909e