### PR TITLE
Add depth parameter to analysis pipeline

### DIFF
--- a/backend/agents/orchestrator_agent.py
+++ b/backend/agents/orchestrator_agent.py
@@ -13,14 +13,17 @@ from ..utils.logger import logger
 
 
 def run_pipeline(
-    company_url: str, company_name: Optional[str] = None
+    company_url: str,
+    company_name: Optional[str] = None,
+    depth: int = 1,
 ) -> Dict[str, object]:
     """Run scraping, LinkedIn enrichment and final analysis."""
     step = "Pipeline"
     logger.info("%s START: %s %s", step, company_url, company_name)
     start = time.perf_counter()
+    depth = max(1, depth)
     try:
-        scrape_result = orchestrate_scraping(company_url)
+        scrape_result = orchestrate_scraping(company_url, depth)
         if not company_name:
             company_name = scrape_result.get("company_name", company_url)
         linkedin_result = orchestrate_linkedin(company_name, contacts=True)

--- a/backend/main.py
+++ b/backend/main.py
@@ -58,12 +58,13 @@ def find_linkedin(
 class AnalyzeRequest(BaseModel):
     website: str
     company: str | None = None
+    depth: int = 1
 
 
 @app.post("/analyze")
 def analyze(req: AnalyzeRequest):
     """Run the full analysis pipeline for a company website."""
-    result = run_pipeline(req.website, req.company)
+    result = run_pipeline(req.website, req.company, req.depth)
     return result
 
 


### PR DESCRIPTION
## Summary
- allow specifying crawl depth in orchestrator pipeline
- expose depth on `/analyze` endpoint
- test orchestrate_scraping depth logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687d52ad3208832fb2e05c0abce5f4c3