### PR TITLE
Update reporter to enforce Turkish output

### DIFF
--- a/backend/agents/reporter_agent.py
+++ b/backend/agents/reporter_agent.py
@@ -63,6 +63,7 @@ footer{text-align:center;font-size:14px;color:#003366;position:fixed;bottom:0;le
 
 REPORT_PROMPT = """
 Delta Proje adına çalışan deneyimli bir satış analistisin. Verilen JSON verilerini kullanarak modern bir danışmanlık raporu üret.
+Tüm yanıtları yalnızca Türkçe olarak ver.
 Her başlıkta sektör odaklı, uygulanabilir ve özgün açıklamalar yap. Veri eksikse 'Bilgi yok' de; kesinlikle uydurma.
 Karar vericiler bölümünde yalnızca Input JSON'daki `decision_makers` listesini kullan; liste boşsa "Bilgi yok" yaz ve yeni isimler uydurma.
 Gerekli durumlarda serpapi, BraveAPI veya Google Custom Search ile güncel haber, yeni atama ve büyüme sinyallerini topla ve kaynağını belirt.

--- a/backend/tests/test_reporter_agent.py
+++ b/backend/tests/test_reporter_agent.py
@@ -1,0 +1,29 @@
+import sys
+import types
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1].parent))
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+from backend.agents.reporter_agent import generate_report
+
+
+class ReporterLanguageTest(unittest.TestCase):
+    @patch("backend.agents.reporter_agent.client.chat.completions.create")
+    def test_generate_report_returns_turkish(self, mock_create):
+        msg = types.SimpleNamespace(
+            content="Merhaba dünya",
+            tool_calls=None,
+            model_dump=lambda: {"role": "assistant", "content": "Merhaba dünya"},
+        )
+        mock_create.return_value = types.SimpleNamespace(choices=[types.SimpleNamespace(message=msg)])
+
+        result = generate_report('{"company_summary": "Test", "decision_makers": []}')
+        self.assertIn("Merhaba", result["html"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- clarify Reporter agent prompt to always answer in Turkish
- add a reporter agent unit test checking for Turkish output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687d53e3044c832fa9e24dd413f274d9