### PR TITLE
Add production details fields

### DIFF
--- a/backend/agents/data_analyst_agent.py
+++ b/backend/agents/data_analyst_agent.py
@@ -31,13 +31,18 @@ def make_prompt(
         "\n"
         "Your job: Synthesize all this data into a concise, practical, and actionable summary for a sales team. "
         "Focus on insights that would help a sales rep decide how, why, and to whom to reach out. "
-        "Highlight decision-makers, sales opportunities, recent developments, and anything that could impact a sales pitch.\n"
+        "Highlight decision-makers, sales opportunities, recent developments, and anything that could impact a sales pitch. "
+        "Include information on production technology, machinery used, services offered, and R&D activities whenever available.\n"
         "\n"
         "Output only valid JSON using this format:\n"
         "{\n"
         '  "company_summary": "",\n'
         '  "sector": "",\n'
         '  "products_services": "",\n'
+        '  "production_technology": "",\n'
+        '  "machinery": "",\n'
+        '  "services": "",\n'
+        '  "r_and_d": "",\n'
         '  "decision_makers": [\n'
         '    {"full_name": "", "title": "", "summary": ""}\n'
         "  ],\n"

--- a/backend/agents/enhanced_search_agent.py
+++ b/backend/agents/enhanced_search_agent.py
@@ -6,7 +6,10 @@ from .search_agent import run_search
 QUERY_MAP = {
     "foundation": ["foundation year", "established"],
     "production_capacity": ["production capacity"],
-    "r_and_d": ["R&D investment", "research and development"],
+    "production_technology": ["production technology", "manufacturing technology"],
+    "machinery": ["machinery", "equipment"],
+    "services": ["services", "service offerings"],
+    "r_and_d": ["R&D investment", "research and development", "innovation"],
     "references": ["customer references", "case studies"],
     "decision_makers": ["leadership team", "executives"],
     "growth_signals": ["growth signals", "investment", "expansion", "hiring"],

--- a/backend/agents/orchestrator_agent.py
+++ b/backend/agents/orchestrator_agent.py
@@ -42,6 +42,9 @@ def run_pipeline(
                 for field in [
                     "foundation",
                     "production_capacity",
+                    "production_technology",
+                    "machinery",
+                    "services",
                     "r_and_d",
                     "references",
                     "decision_makers",


### PR DESCRIPTION
## Summary
- expand enhanced search topics to gather production tech, machinery, services, and R&D info
- request the same details from the LLM in the analyst prompt and JSON schema
- ensure orchestrator retries missing production fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687d54a436f0832fa5e22960295af965