### PR TITLE
Expand search results and update LinkedIn agent

### DIFF
--- a/backend/agents/linkedin_agent.py
+++ b/backend/agents/linkedin_agent.py
@@ -26,26 +26,17 @@ def _parse_contact(result: Dict[str, str]) -> Dict[str, str]:
 
 
 def _search_all(query: str) -> Dict[str, List[Dict[str, str]]]:
-    """Run SerpAPI, Brave and Google searches sequentially."""
+    """Run SerpAPI, Brave and Google searches."""
     results = {"serpapi": [], "brave": [], "google": []}
-    try:
-        results["serpapi"] = serpapi_search(query)
-    except Exception as exc:
-        logger.exception("serpapi_search failed: %s", exc)
-
-    if not any("linkedin.com" in r.get("url", "") for r in results["serpapi"]):
+    for name, func in [
+        ("serpapi", serpapi_search),
+        ("brave", brave_search),
+        ("google", google_cse_search),
+    ]:
         try:
-            results["brave"] = brave_search(query)
+            results[name] = func(query)
         except Exception as exc:
-            logger.exception("brave_search failed: %s", exc)
-
-    if not any(
-        "linkedin.com" in r.get("url", "") for lst in results.values() for r in lst
-    ):
-        try:
-            results["google"] = google_cse_search(query)
-        except Exception as exc:
-            logger.exception("google_custom_search failed: %s", exc)
+            logger.exception("%s search failed: %s", name, exc)
 
     return results
 

--- a/backend/tests/test_linkedin_agent.py
+++ b/backend/tests/test_linkedin_agent.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1].parent))
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+from backend.agents.linkedin_agent import _search_all
+
+
+class SearchAllResultsTest(unittest.TestCase):
+    @patch("backend.agents.linkedin_agent.google_cse_search")
+    @patch("backend.agents.linkedin_agent.brave_search")
+    @patch("backend.agents.linkedin_agent.serpapi_search")
+    def test_returns_at_least_ten(self, mock_serpapi, mock_brave, mock_google):
+        mock_serpapi.return_value = [{"url": "https://linkedin.com/1"}] * 4
+        mock_brave.return_value = [{"url": "https://linkedin.com/2"}] * 4
+        mock_google.return_value = [{"url": "https://linkedin.com/3"}] * 4
+
+        results = _search_all("acme")
+        total = sum(len(v) for v in results.values())
+        self.assertGreaterEqual(total, 10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tools/search_tools.py
+++ b/backend/tools/search_tools.py
@@ -33,7 +33,7 @@ def brave_search(query: str) -> List[Dict[str, str]]:
     if not BRAVE_API_KEY:
         raise ValueError("BRAVE_API_KEY not set")
 
-    params = {"q": query, "count": 3}
+    params = {"q": query, "count": 10}
     headers = {
         "Accept": "application/json",
         "X-Subscription-Token": BRAVE_API_KEY,
@@ -43,7 +43,7 @@ def brave_search(query: str) -> List[Dict[str, str]]:
     data = resp.json()
     items = data.get("web", {}).get("results", [])
     results: List[Dict[str, str]] = []
-    for hit in items[:3]:
+    for hit in items[:10]:
         results.append(
             {
                 "title": hit.get("title", ""),
@@ -63,12 +63,12 @@ def serpapi_search(query: str) -> List[Dict[str, str]]:
     if not SERPAPI_API_KEY:
         raise ValueError("SERPAPI_API_KEY not set")
 
-    params = {"engine": "google", "q": query, "api_key": SERPAPI_API_KEY, "num": 3}
+    params = {"engine": "google", "q": query, "api_key": SERPAPI_API_KEY, "num": 10}
     resp = requests.get(SERPAPI_URL, params=params, timeout=10)
     resp.raise_for_status()
     data = resp.json()
     results: List[Dict[str, str]] = []
-    for item in data.get("organic_results", [])[:3]:
+    for item in data.get("organic_results", [])[:10]:
         results.append(
             {
                 "title": item.get("title", ""),
@@ -89,12 +89,12 @@ def google_cse_search(query: str) -> List[Dict[str, str]]:
     if not GOOGLE_API_KEY or not GOOGLE_CSE_ID:
         raise ValueError("GOOGLE_API_KEY or GOOGLE_CSE_ID not set")
 
-    params = {"key": GOOGLE_API_KEY, "cx": GOOGLE_CSE_ID, "q": query}
+    params = {"key": GOOGLE_API_KEY, "cx": GOOGLE_CSE_ID, "q": query, "num": 10}
     resp = requests.get(GOOGLE_CSE_URL, params=params, timeout=10)
     resp.raise_for_status()
     data = resp.json()
     results: List[Dict[str, str]] = []
-    for item in data.get("items", [])[:3]:
+    for item in data.get("items", [])[:10]:
         results.append(
             {
                 "title": item.get("title", ""),


### PR DESCRIPTION
## Summary
- fetch up to 10 results from each search tool
- always run all search engines in `linkedin_agent`
- test `_search_all` for at least 10 combined results

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687d55ea7574832f891587ee51251a73