### PR TITLE
Fix backend README instructions

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -5,6 +5,7 @@ Bu dizin FastAPI tabanlı REST servislerini içerir. Her bir ajan ve workflow mo
 ## Çalıştırma
 Komutları depo kök dizininden çalıştırın:
 ```bash
+cd backend
 pip install -r requirements.txt
 cd ..
 uvicorn backend.main:app --reload


### PR DESCRIPTION
## Summary
- fix backend README commands to cd into backend before installing requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687e662fc050832fa82f60d02e5dbaa4