### PR TITLE
Implement real API calls in progress steps

### DIFF
--- a/frontend/src/components/MainCard.tsx
+++ b/frontend/src/components/MainCard.tsx
@@ -70,13 +70,28 @@ export default function MainCard() {
 
     const s1 = performance.now();
     update(1, { status: 'in-progress' });
-    await new Promise((r) => setTimeout(r, 500));
-    update(1, { status: 'success', duration: performance.now() - s1 });
+    try {
+      const res = await fetch('/scrape?url=' + encodeURIComponent(query));
+      if (!res.ok) throw new Error('scrape failed');
+      await res.json();
+      update(1, { status: 'success', duration: performance.now() - s1 });
+    } catch (err) {
+      update(1, { status: 'error', duration: performance.now() - s1 });
+    }
 
     const s2 = performance.now();
     update(2, { status: 'in-progress' });
-    await new Promise((r) => setTimeout(r, 500));
-    update(2, { status: 'success', duration: performance.now() - s2 });
+    try {
+      const res = await fetch(
+        '/find_linkedin?company=' +
+          encodeURIComponent(company || query)
+      );
+      if (!res.ok) throw new Error('linkedin failed');
+      await res.json();
+      update(2, { status: 'success', duration: performance.now() - s2 });
+    } catch (err) {
+      update(2, { status: 'error', duration: performance.now() - s2 });
+    }
 
     const s3 = performance.now();
     update(3, { status: 'in-progress' });


### PR DESCRIPTION
## Summary
- use `/scrape` and `/find_linkedin` endpoints when running the pipeline
- show success/error status and timing based on the HTTP requests

## Testing
- `pytest -q`
- started `uvicorn` backend and vite frontend to ensure endpoints respond


------
https://chatgpt.com/codex/tasks/task_b_687e69bd1ae0832f99b95e26c0a06b7d