### PR TITLE
Fix favicon path

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+  <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <title>InsightChain</title>
   </head>
   <body>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  base: './',
   plugins: [react()],
   server: {
     port: 5173,


### PR DESCRIPTION
## Summary
- link favicon relative to index
- set Vite base to `./` for relative asset paths

## Testing
- `pytest`
- `npm run build` in `frontend/`


------
https://chatgpt.com/codex/tasks/task_b_687e938664e4832f8049eeafdc1b47c2