### PR TITLE
Improve backend & frontend error handling

### DIFF
--- a/frontend/src/components/ConnectionPopup.tsx
+++ b/frontend/src/components/ConnectionPopup.tsx
@@ -75,10 +75,16 @@ export default function ConnectionPopup({ onRetry, onClose }: Props) {
         {success && (
           <div className="space-y-4">
             <p>✅ Bağlantı başarılı. Pencereyi kapatıp işlemlerinize devam edebilirsiniz.</p>
-            <div className="flex justify-end">
-              <button onClick={onClose} className="px-3 py-1 bg-blue-900 text-white rounded">
-                Kapat
-              </button>
+            <div className="flex justify-between items-center">
+              <div />
+              <div className="flex space-x-2">
+                <button onClick={onClose} className="px-3 py-1 bg-blue-900 text-white rounded">
+                  Kapat
+                </button>
+                <button onClick={handleRetry} className="px-3 py-1 bg-blue-900 text-white rounded">
+                  Tekrar Dene
+                </button>
+              </div>
             </div>
           </div>
         )}

--- a/frontend/src/components/PipelineProgress.tsx
+++ b/frontend/src/components/PipelineProgress.tsx
@@ -6,13 +6,16 @@ export interface Step {
   label: string;
   status: StepStatus;
   duration?: number; // in milliseconds
+  message?: string;
 }
 
 interface Props {
   steps: Step[];
+  error?: string;
+  onRetry: () => void;
 }
 
-export default function PipelineProgress({ steps }: Props) {
+export default function PipelineProgress({ steps, error, onRetry }: Props) {
   return (
     <div className="bg-slate-900 text-white p-4 rounded-lg w-full max-w-md font-mono text-sm space-y-1">
       {steps.map((step, idx) => (
@@ -29,8 +32,17 @@ export default function PipelineProgress({ steps }: Props) {
                 <span className="text-slate-400">{Math.round(step.duration)} ms</span>
               )}
           </span>
+          {step.message && step.status === 'error' && (
+            <span className="text-red-400 text-xs ml-2">{step.message}</span>
+          )}
         </div>
       ))}
+      <div className="pt-2 flex justify-between items-center">
+        {error && <span className="text-red-400 text-xs">{error}</span>}
+        <button onClick={onRetry} className="px-3 py-1 bg-blue-900 rounded text-white text-xs">
+          Tekrar Dene
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add global error handler in FastAPI
- rotate Google API keys and expose clear messages
- surface API errors on the frontend and display retry buttons
- show retry button in connection popup even after success

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687e9c7ab62c832fac77d5e40deb19a3