### PR TITLE
Optimize search API usage

### DIFF
--- a/backend/agents/search_agent.py
+++ b/backend/agents/search_agent.py
@@ -8,13 +8,51 @@ from ..tools.search_tools import (
     brave_search,
     google_cse_search,
 )
+from ..utils.logger import logger
+
+TOOL_SEQUENCE = [
+    "google_cse_search",
+    "serpapi_search",
+    "brave_search",
+]
+
+TOOL_LABELS = {
+    "google_cse_search": "google_cse",
+    "serpapi_search": "serpapi",
+    "brave_search": "brave",
+}
 
 
 def run_search(keywords: List[str]) -> List[Dict[str, str]]:
-    """Aggregate results from multiple search tools."""
+    """Search each keyword using the tool sequence until results are found.
+
+    Duplicate keyword queries are ignored within a single call.
+    """
     results: List[Dict[str, str]] = []
+    seen = set()
     for kw in keywords:
-        results.extend(serpapi_search(kw))
-        results.extend(brave_search(kw))
-        results.extend(google_cse_search(kw))
+        if kw in seen:
+            logger.info("SearchAgent skip duplicate query=%s", kw)
+            continue
+        seen.add(kw)
+        for name in TOOL_SEQUENCE:
+            func = globals()[name]
+            label = TOOL_LABELS[name]
+            try:
+                logger.info("SearchAgent CALL tool=%s query=%s", label, kw)
+                res = func(kw)
+                logger.info(
+                    "SearchAgent RESULT tool=%s query=%s count=%d",
+                    label,
+                    kw,
+                    len(res),
+                )
+                if res:
+                    results.extend(res)
+                    break
+            except Exception as exc:
+                logger.exception(
+                    "SearchAgent ERROR tool=%s query=%s: %s", label, kw, exc
+                )
+                continue
     return results


### PR DESCRIPTION
## Summary
- avoid duplicate queries by caching in search agent
- short-circuit tool chain when first result found
- log API calls in EnhancedSearchAgent and ReporterAgent
- add tests for new search behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ea17db290832f8e2cc418207b04fe